### PR TITLE
Release build and some fixes

### DIFF
--- a/.github/workflows/check_gcc.yml
+++ b/.github/workflows/check_gcc.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build
         run: |
           shopt -s extglob
-          g++ --std=c++20 -o RangeShifter ./src/*.cpp ./src/RScore/!(Main).cpp -DRSDEBUG -DRSWIN64 -DLINUX_CLUSTER
+          g++ --std=c++20 -o RangeShifter ./src/*.cpp ./src/RScore/!(Main).cpp -DLINUX_CLUSTER
 
       - name: run
         run: ./RangeShifter ./run_on_gha/rs_test_project/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	add_compile_definitions(LINUX_CLUSTER)
 endif()
 
-# Debug Mode by default, unless "release" is passed i.e. `cmake -Drelease=`
-if(NOT DEFINED release)
-	add_compile_definitions(RSDEBUG)
-endif()
 # link RScore to the executable as a library
 target_link_libraries(RangeShifter PUBLIC RScore)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ add_subdirectory(src/RScore)
 # add the executable
 add_executable(RangeShifter src/Main.cpp src/BatchMode.cpp)
 
-target_compile_definitions(RangeShifter PRIVATE RSWIN64)
-
 # enable LINUX_CLUSTER macro on Linux + macOS
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	add_compile_definitions(LINUX_CLUSTER)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RangeShifter Batch Mode <img src="doc/RS_logo.png" align="right" height = 100/>
+
 C++ code for the RangeShifter v2 batch mode application
 
 <img title="" src="https://github.com/RangeShifter/RangeShifter_batch_dev/blob/main/doc/rs_batch_logo.png" alt="" align="right" height="150">
@@ -24,12 +25,12 @@ The compiled software can be found in the [Software and Documentation](https://g
 
 Building RangeShifter from the source code requires CMake. If you haven't done so yet, you will need to [download and install it](https://cmake.org/download/).
 
-RangeShifter can then be configured and built (out-of-source) from `CMakeLists.txt`, with the usual CMake commands:
+RangeShifter can then be configured and built from `CMakeLists.txt`:
 
 ```bash
 mkdir build && cd build
 cmake ..
-cmake --build .
+cmake --build . --config Release
 ```
 
 If you use Visual Studio as your IDE, CMake should be recognised automatically when `RangeShifter_batch_dev` is opened as a new folder. 
@@ -40,7 +41,7 @@ In this case, some #define macros must be passed to it, and RScore/Main.cpp must
 
 ```bash
 shopt -s extglob # enable the !(file) pattern below
-g++ --std=c++20 -o RangeShifter.exe ./src/*.cpp ./src/RScore/!(Main).cpp -DRSDEBUG -DRSWIN64 -DLINUX_CLUSTER
+g++ --std=c++20 -o RangeShifter.exe ./src/*.cpp ./src/RScore/!(Main).cpp -DRSWIN64 -DLINUX_CLUSTER
 ```
 
 ## Running RangeShifter
@@ -63,7 +64,7 @@ See [CONTRIBUTING](https://github.com/RangeShifter/RangeShifter_batch_dev/blob/m
 
 ## References
 
- - Bocedi G, Palmer SCF, Pe’er G, Heikkinen RK, Matsinos YG, Watts K, Travis JMJ (2014). 
- *RangeShifter: A Platform for Modelling Spatial Eco-Evolutionary Dynamics and 
- Species’ Responses to Environmental Changes.* Methods in Ecology and Evolution 5: 388–96. 
- - Bocedi G, Palmer SCF, Malchow AK, Zurell D, Watts K, Travis JMJ (2021) *RangeShifter 2.0: An extended and enhanced platform for modelling spatial eco-evolutionary dynamics and species’ responses to environmental changes.* Ecography 44:1453-1462.
+- Bocedi G, Palmer SCF, Pe’er G, Heikkinen RK, Matsinos YG, Watts K, Travis JMJ (2014). 
+  *RangeShifter: A Platform for Modelling Spatial Eco-Evolutionary Dynamics and 
+  Species’ Responses to Environmental Changes.* Methods in Ecology and Evolution 5: 388–96. 
+- Bocedi G, Palmer SCF, Malchow AK, Zurell D, Watts K, Travis JMJ (2021) *RangeShifter 2.0: An extended and enhanced platform for modelling spatial eco-evolutionary dynamics and species’ responses to environmental changes.* Ecography 44:1453-1462.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In this case, some #define macros must be passed to it, and RScore/Main.cpp must
 
 ```bash
 shopt -s extglob # enable the !(file) pattern below
-g++ --std=c++20 -o RangeShifter.exe ./src/*.cpp ./src/RScore/!(Main).cpp -DRSWIN64 -DLINUX_CLUSTER
+g++ --std=c++20 -o RangeShifter.exe ./src/*.cpp ./src/RScore/!(Main).cpp -DLINUX_CLUSTER -O3 -s -DNDEBUG
 ```
 
 ## Running RangeShifter

--- a/src/BatchMode.cpp
+++ b/src/BatchMode.cpp
@@ -1451,7 +1451,7 @@ int CheckLandFile(int landtype, string indir)
 }
 
 int CheckDynamicFile(string indir, string costfile) {
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "ParseDynamicFile(): costfile=" << costfile << endl;
 #endif
 	string header, filename, fname, ftype, intext;
@@ -5328,7 +5328,7 @@ int ReadParameters(int option, Landscape* pLandscape)
 	else {
 		if (sim.outConnect) error = 105;
 	}
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "ReadParameters(): outRange=" << sim.outRange << " outInt=" << sim.outIntRange
 		<< endl;
 #endif

--- a/src/BatchMode.h
+++ b/src/BatchMode.h
@@ -225,7 +225,7 @@ set<int> stringToStages(const string&, const int&);
 set<int> stringToChromosomeEnds(string, const int&);
 GenParamType strToGenParamType(const string& str);
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -63,13 +63,13 @@ using namespace std;
 #include <direct.h>
 #endif
 
-#if RSDEBUG
+#ifndef NDEBUG
 void run_batch_unit_tests() {
 	cout << "******* Unit test output for batch interface *******" << endl;
 	// call tests here
 	cout << endl << "************************" << endl;
 }
-#endif // RSDEBUG
+#endif // NDEBUG
 
 string habmapname,patchmapname,distnmapname;	// req'd for compilation, but not used
 string costmapname,genfilename;					 			// ditto
@@ -84,7 +84,7 @@ Species *pSpecies;  				// pointer to species
 Community *pComm;						// pointer to community
 RSrandom *pRandom;          // pointer to random number routines
 
-#if RSDEBUG
+#ifndef NDEBUG
 ofstream DEBUGLOG;
 ofstream MUTNLOG;
 #endif
@@ -97,13 +97,13 @@ int _tmain(int argc, _TCHAR* argv[])
 #endif
 {
 
-#if RSDEBUG
+#ifndef NDEBUG
 	cout << "RangeShifter Debug Mode" << endl;
 #else
 	cout << "RangeShifter Release Mode" << endl;
 #endif
 
-#if RSDEBUG
+#ifndef NDEBUG
 	assert(0.1 > 0.0); // assert does run correctly
 	run_batch_unit_tests();
 #else
@@ -176,7 +176,7 @@ else {
 	pathToControlFile = paramsSim->getDir(0) + "Inputs\\CONTROL.txt";
 }
 #endif
-#if RSDEBUG
+#ifndef NDEBUG
 cout << endl << "Working directory: " << paramsSim->getDir(0) << endl;
 cout << endl << "Inputs folder:     " << paramsSim->getDir(1) << endl;
 cout << endl << "Control file:      " << pathToControlFile << endl << endl;
@@ -194,7 +194,7 @@ if (errorfolder) {
 	return 666;
 }
 
-#if RSDEBUG
+#ifndef NDEBUG
 // set up debugging log file
 string name = paramsSim->getDir(2) + "DebugLog.txt";
 DEBUGLOG.open(name.c_str());
@@ -246,7 +246,7 @@ else {
 
 // set up random number class
 #if RS_RCPP
-	#if RSDEBUG
+	#ifndef NDEBUG
 		pRandom = new RSrandom(666);
 	#else
 		pRandom = new RSrandom(-1);  // need to be replaced with parameter from control file
@@ -273,7 +273,7 @@ if (b.ok) {
 
 delete pRandom;
 
-#if RSDEBUG
+#ifndef NDEBUG
 if (DEBUGLOG.is_open()) {
 	DEBUGLOG.close(); DEBUGLOG.clear();
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -97,10 +97,10 @@ int _tmain(int argc, _TCHAR* argv[])
 #endif
 {
 
-#ifndef NDEBUG
-	cout << "RangeShifter Debug Mode" << endl;
-#else
+#ifdef NDEBUG
 	cout << "RangeShifter Release Mode" << endl;
+#else
+	cout << "RangeShifter Debug Mode" << endl;
 #endif
 
 #ifndef NDEBUG

--- a/src/RScore/CMakeLists.txt
+++ b/src/RScore/CMakeLists.txt
@@ -20,10 +20,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	add_compile_definitions("LINUX_CLUSTER")
 endif()
 
-# Debug Mode by default, unless "release" is passed
-if(NOT DEFINED release)
-	add_compile_definitions(RSDEBUG)
-endif()
 
 if(NOT batchmode)
 	target_include_directories(RScore PUBLIC "${PROJECT_BINARY_DIR}")

--- a/src/RScore/CMakeLists.txt
+++ b/src/RScore/CMakeLists.txt
@@ -12,9 +12,6 @@ else() # that is, RScore compiled as library within RangeShifter_batch
 	add_library(RScore Species.cpp Cell.cpp Community.cpp FractalGenerator.cpp GeneticFitnessTrait.cpp Individual.cpp Landscape.cpp Model.cpp NeutralStatsManager.cpp Parameters.cpp Patch.cpp Population.cpp DispersalTrait.cpp RSrandom.cpp NeutralTrait.cpp SpeciesTrait.cpp SubCommunity.cpp Utils.cpp)
 endif()
 
-# pass config definitions to compiler
-target_compile_definitions(RScore PRIVATE RSWIN64)
-
 # enable LINUX_CLUSTER macro on Linux + macOS
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	add_compile_definitions("LINUX_CLUSTER")

--- a/src/RScore/Community.cpp
+++ b/src/RScore/Community.cpp
@@ -411,7 +411,7 @@ void Community::dispersal(short landIx, short nextseason)
 void Community::dispersal(short landIx)
 #endif // RS_RCPP
 {
-#if RSDEBUG
+#ifndef NDEBUG
 	time_t t0, t1, t2;
 	t0 = time(0);
 #endif
@@ -424,7 +424,7 @@ void Community::dispersal(short landIx)
 	for (int i = 0; i < nsubcomms; i++) { // all populations
 		subComms[i]->initiateDispersal(matrix);
 	}
-#if RSDEBUG
+#ifndef NDEBUG
 	t1 = time(0);
 	DEBUGLOG << "Community::dispersal(): this=" << this
 		<< " nsubcomms=" << nsubcomms << " initiation time=" << t1 - t0 << endl;
@@ -445,7 +445,7 @@ void Community::dispersal(short landIx)
 		matrix->completeDispersal(pLandscape, sim.outConnect);
 	} while (ndispersers > 0);
 
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Community::dispersal(): matrix=" << matrix << endl;
 	t2 = time(0);
 	DEBUGLOG << "Community::dispersal(): transfer time=" << t2 - t1 << endl;
@@ -508,7 +508,7 @@ void Community::createOccupancy(int nrows, int reps) {
 
 void Community::updateOccupancy(int row, int rep)
 {
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Community::updateOccupancy(): row=" << row << endl;
 #endif
 	int nsubcomms = (int)subComms.size();
@@ -630,7 +630,7 @@ bool Community::outRangeHeaders(Species* pSpecies, int landNr)
 	transferRules trfr = pSpecies->getTransferRules();
 	settleType sett = pSpecies->getSettle();
 
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Community::outRangeHeaders(): simulation=" << sim.simulation
 		<< " sim.batchMode=" << sim.batchMode
 		<< " landNr=" << landNr << endl;
@@ -720,7 +720,7 @@ bool Community::outRangeHeaders(Species* pSpecies, int landNr)
 	}
 	outrange << endl;
 
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Community::outRangeHeaders(): finished" << endl;
 #endif
 
@@ -730,7 +730,7 @@ bool Community::outRangeHeaders(Species* pSpecies, int landNr)
 // Write record to range file
 void Community::outRange(Species* pSpecies, int rep, int yr, int gen)
 {
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Community::outRange(): rep=" << rep
 		<< " yr=" << yr << " gen=" << gen << endl;
 #endif

--- a/src/RScore/DispersalTrait.cpp
+++ b/src/RScore/DispersalTrait.cpp
@@ -462,7 +462,7 @@ float DispersalTrait::getDomCoefAtLocus(short whichChromosome, int position) con
 	return it->second[whichChromosome]->getDominanceCoef();
 }
 
-#if RSDEBUG // Testing only
+#ifndef NDEBUG // Testing only
 
 // Get allele ID at locus
 int DispersalTrait::getAlleleIDAtLocus(short whichChromosome, int position) const {
@@ -473,7 +473,7 @@ int DispersalTrait::getAlleleIDAtLocus(short whichChromosome, int position) cons
 }
 #endif
 
-#if RSDEBUG
+#ifndef NDEBUG
 
 // Create a default set of alleles for testing
 //
@@ -500,4 +500,4 @@ map<int, vector<shared_ptr<Allele>>> createTestGenotype(
 	}
 	return genotype;
 }
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/DispersalTrait.h
+++ b/src/RScore/DispersalTrait.h
@@ -46,7 +46,7 @@ public:
 	int countHeterozygoteLoci() const;
 	bool isHeterozygoteAtLocus(int locus) const override;
 
-#if RSDEBUG // for testing only
+#ifndef NDEBUG // for testing only
 	void overwriteGenes(map<int, vector<shared_ptr<Allele>>> genSeq) {
 		genes = genSeq;
 	}
@@ -95,7 +95,7 @@ private:
 	float expressAdditive();
 };
 
-#if RSDEBUG
+#ifndef NDEBUG
 // Test utilities
 
 map<int, vector<shared_ptr<Allele>>> createTestGenotype(
@@ -105,6 +105,6 @@ map<int, vector<shared_ptr<Allele>>> createTestGenotype(
 	const float domCoeffA = 1.0, // default for dispersal traits
 	const float domCoeffB = 1.0
 );
-#endif //RSDEBUG
+#endif // NDEBUG
 
 #endif // DISPTRAITH

--- a/src/RScore/GeneticFitnessTrait.cpp
+++ b/src/RScore/GeneticFitnessTrait.cpp
@@ -434,7 +434,7 @@ float GeneticFitnessTrait::getDomCoefAtLocus(short whichChromosome, int position
 	return it->second[whichChromosome] == 0 ? wildType->getDominanceCoef() : it->second[whichChromosome]->getDominanceCoef();
 }
 
-#if RSDEBUG // Testing only
+#ifndef NDEBUG // Testing only
 // Get allele ID at locus
 int GeneticFitnessTrait::getAlleleIDAtLocus(short whichChromosome, int position) const {
 	auto it = genes.find(position);
@@ -443,4 +443,4 @@ int GeneticFitnessTrait::getAlleleIDAtLocus(short whichChromosome, int position)
 	return it->second[whichChromosome].get()->getId();
 }
 
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/GeneticFitnessTrait.h
+++ b/src/RScore/GeneticFitnessTrait.h
@@ -49,7 +49,7 @@ public:
     virtual float getDomCoefAtLocus(short chromosome, int position) const override;
     virtual int countHeterozygoteLoci() const;
     virtual bool isHeterozygoteAtLocus(int locus) const override;
-#if RSDEBUG // for testing only
+#ifndef NDEBUG // for testing only
     int getAlleleIDAtLocus(short whichChromosome, int position) const;
 #endif
 

--- a/src/RScore/Individual.cpp
+++ b/src/RScore/Individual.cpp
@@ -738,7 +738,7 @@ int Individual::moveKernel(Landscape* pLandscape, Species* pSpecies, const bool 
 				ny = yrand + dist * cos(rndangle);
 				if (nx < 0.0) newX = -1; else newX = (int)nx;
 				if (ny < 0.0) newY = -1; else newY = (int)ny;
-#if RSDEBUG
+#ifndef NDEBUG
 				if (path != 0) (path->year)++;
 #endif
 				loopsteps++;
@@ -1596,7 +1596,7 @@ double cauchy(double location, double scale) {
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 
-#if RSDEBUG
+#ifndef NDEBUG
 // Testing utilities
 
 Cell* Individual::getCurrCell() const {
@@ -1664,5 +1664,5 @@ void Individual::overrideGenotype(TraitType whichTrait, const map<int, vector<un
 	pNeutralTrait->getGenes() = newGenotype;
 };
 
-#endif // RSDEBUG
+#endif // NDEBUG
 

--- a/src/RScore/Individual.h
+++ b/src/RScore/Individual.h
@@ -341,7 +341,7 @@ public:
 		const int		 	// year
 	);
 #endif
-#if RSDEBUG
+#ifndef NDEBUG
 	// Testing utilities
 	Cell* getCurrCell() const;
 	void setInitAngle(const float angle);
@@ -395,7 +395,7 @@ double wrpcauchy(double location, double rho = exp(double(-1)));
 
 extern RSrandom* pRandom;
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/RScore/Landscape.cpp
+++ b/src/RScore/Landscape.cpp
@@ -1125,7 +1125,7 @@ int Landscape::readLandChange(int filenum, bool costs)
 #endif
 {
 
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Landscape::readLandChange(): filenum=" << filenum << " costs=" << int(costs)
 		<< endl;
 #endif
@@ -1600,7 +1600,7 @@ void Landscape::createCostsChgMatrix(void)
 }
 
 void Landscape::recordCostChanges(int landIx) {
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "Landscape::recordCostChanges(): landIx=" << landIx << endl;
 #endif
 	if (costsChgMatrix == 0) return; // should not occur
@@ -2289,7 +2289,7 @@ int Landscape::readCosts(string fname)
 
 	int maxcost = 0;
 
-#if RSDEBUG
+#ifndef NDEBUG
 #if BATCH
 	DEBUGLOG << "Landscape::readCosts(): fname=" << fname << endl;
 #endif
@@ -2529,7 +2529,7 @@ void Landscape::outPathsHeaders(int rep, int option)
 			outMovePaths << "Year\tIndID\tStep\tx\ty\tStatus" << endl;
 		}
 		else {
-#if RSDEBUG
+#ifndef NDEBUG
 			DEBUGLOG << "RunModel(): UNABLE TO OPEN MOVEMENT PATHS FILE" << endl;
 #endif
 			outMovePaths.clear();
@@ -2650,7 +2650,7 @@ void Landscape::outVisits(int rep, int landNr) {
 
 //---------------------------------------------------------------------------
 
-#if RSDEBUG
+#ifndef NDEBUG
 // Debug only: shortcut setup utilities
 
 Landscape createLandscapeFromCells(vector<Cell*> cells, const landParams& lp, Species sp) {
@@ -2687,7 +2687,7 @@ landParams createDefaultLandParams(const int& dim) {
 void testLandscape() {
 	// test coordinate system...
 }
-#endif // RSDEBUG
+#endif // NDEBUG
 
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------

--- a/src/RScore/Landscape.cpp
+++ b/src/RScore/Landscape.cpp
@@ -171,14 +171,14 @@ int InitDist::readDistribution(string distfile) {
 #endif
 
 	// open distribution file
-#if !RS_RCPP || RSWIN64
-	dfile.open(distfile.c_str());
-#else
+#if RS_RCPP
 	dfile.open(distfile, std::ios::binary);
 	if (spdistraster.utf) {
 		// apply BOM-sensitive UTF-16 facet
 		dfile.imbue(std::locale(dfile.getloc(), new std::codecvt_utf16<wchar_t, 0x10ffff, std::consume_header>));
 	}
+#else
+	dfile.open(distfile.c_str());
 #endif
 	if (!dfile.is_open()) return 21;
 
@@ -1790,26 +1790,26 @@ int Landscape::readLandscape(int fileNum, string habfile, string pchfile, string
 	initParams init = paramsInit->getInit();
 
 	// open habitat file and optionally also patch file
-#if !RS_RCPP || RSWIN64
-	hfile.open(habfile.c_str());
-#else
+#if RS_RCPP
 	hfile.open(habfile, std::ios::binary);
 	if (landraster.utf) {
 		// apply BOM-sensitive UTF-16 facet
 		hfile.imbue(std::locale(hfile.getloc(), new std::codecvt_utf16<wchar_t, 0x10ffff, std::consume_header>));
 	}
+#else
+	hfile.open(habfile.c_str());
 #endif
 	if (!hfile.is_open()) return 11;
 	if (fileNum == 0) {
 		if (patchModel) {
-#if !RS_RCPP || RSWIN64
-			pfile.open(pchfile.c_str());
-#else
+#if RS_RCPP
 			pfile.open(pchfile, std::ios::binary);
 			if (patchraster.utf) {
 				// apply BOM-sensitive UTF-16 facet
 				pfile.imbue(std::locale(pfile.getloc(), new std::codecvt_utf16<wchar_t, 0x10ffff, std::consume_header>));
 			}
+#else
+			pfile.open(pchfile.c_str());
 #endif
 			if (!pfile.is_open()) {
 				hfile.close(); hfile.clear();
@@ -2296,14 +2296,14 @@ int Landscape::readCosts(string fname)
 #endif
 	// open cost file
  // open cost file
-#if !RS_RCPP || RSWIN64
-	costs.open(fname.c_str());
-#else
+#if RS_RCPP
 	costs.open(fname, std::ios::binary);
 	if (costsraster.utf) {
 		// apply BOM-sensitive UTF-16 facet
 		costs.imbue(std::locale(costs.getloc(), new std::codecvt_utf16<wchar_t, 0x10ffff, std::consume_header>));
 	}
+#else
+	costs.open(fname.c_str());
 #endif
 	// read headers and check that they correspond to the landscape ones
 	costs >> header;

--- a/src/RScore/Landscape.h
+++ b/src/RScore/Landscape.h
@@ -530,7 +530,7 @@ extern paramInit* paramsInit;
 extern paramSim* paramsSim;
 extern RSrandom* pRandom;
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 landParams createDefaultLandParams(const int& dim);
 void testLandscape();

--- a/src/RScore/Model.cpp
+++ b/src/RScore/Model.cpp
@@ -125,15 +125,8 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			int npatches = pLandscape->patchCount();
 			for (int i = 0; i < npatches; i++) {
 				ppp = pLandscape->getPatchData(i);
-#if RSWIN64
-#if LINUX_CLUSTER
 				pComm->addSubComm(ppp.pPatch, ppp.patchNum); // SET UP ALL SUB-COMMUNITIES
-#else
-				SubCommunity* pSubComm = pComm->addSubComm(ppp.pPatch, ppp.patchNum); // SET UP ALL SUB-COMMUNITIES
-#endif
-#else
 				pComm->addSubComm(ppp.pPatch, ppp.patchNum); // SET UP ALL SUB-COMMUNITIES
-#endif
 			}
 			if (sim.patchSamplingOption == "random") {
 				// Then patches must be resampled for new landscape

--- a/src/RScore/Model.cpp
+++ b/src/RScore/Model.cpp
@@ -409,7 +409,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 			for (int gen = 0; gen < dem.repSeasons; gen++) // generation loop
 			{
-#if RSDEBUG
+#ifndef NDEBUG
 				// TEMPORARY RANDOM STREAM CHECK
 				if (yr % 1 == 0)
 				{
@@ -718,13 +718,13 @@ bool CheckDirectory(void)
 //For outputs and population visualisations pre-reproduction
 void PreReproductionOutput(Landscape* pLand, Community* pComm, int rep, int yr, int gen)
 {
-#if RSDEBUG
+#ifndef NDEBUG
 	landParams ppLand = pLand->getLandParams();
 #endif
 	simParams sim = paramsSim->getSim();
 	simView v = paramsSim->getViews();
 
-#if RSDEBUG
+#ifndef NDEBUG
 	DEBUGLOG << "PreReproductionOutput(): 11111 rep=" << rep << " yr=" << yr << " gen=" << gen
 		<< " landNum=" << ppLand.landNum << " maxX=" << ppLand.maxX << " maxY=" << ppLand.maxY
 		<< endl;

--- a/src/RScore/Model.cpp
+++ b/src/RScore/Model.cpp
@@ -784,13 +784,6 @@ void OutParameters(Landscape* pLandscape)
 
 	outPar << "RangeShifter 2.0 ";
 
-#if !RS_RCPP
-#if RSWIN64
-	outPar << " - 64 bit implementation";
-#else
-	outPar << " - 32 bit implementation";
-#endif
-#endif
 	outPar << endl;
 
 	outPar << "================ ";

--- a/src/RScore/Model.h
+++ b/src/RScore/Model.h
@@ -61,7 +61,7 @@
 using namespace std::filesystem;
 #endif
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/RScore/NeutralTrait.cpp
+++ b/src/RScore/NeutralTrait.cpp
@@ -290,7 +290,7 @@ float NeutralTrait::getAlleleValueAtLocus(short whichChromosome, int position) c
 	return it->second[whichChromosome];
 }
 
-#if RSDEBUG // Testing only
+#ifndef NDEBUG // Testing only
 // Get allele ID at locus
 int NeutralTrait::getAlleleIDAtLocus(short whichChromosome, int position) const {
 	// for neutral genes this is the same as the allele value
@@ -318,4 +318,4 @@ map<int, vector<unsigned char>> createTestNeutralGenotype(
 	return genotype;
 }
 
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/NeutralTrait.h
+++ b/src/RScore/NeutralTrait.h
@@ -90,7 +90,7 @@ private:
 map<int, vector<unsigned char>> createTestNeutralGenotype(
 	const int genomeSz, const bool isDiploid,
 	const unsigned char valAlleleA,
-	const unsigned char valAlleleB = -99.9 // if haploid
+	const unsigned char valAlleleB = char(0) // if haploid
 );
 #endif
 

--- a/src/RScore/NeutralTrait.h
+++ b/src/RScore/NeutralTrait.h
@@ -53,7 +53,7 @@ public:
 
 	virtual int countHeterozygoteLoci() const;
 	virtual bool isHeterozygoteAtLocus(int locus) const override;
-#if RSDEBUG // for testing only
+#ifndef NDEBUG // for testing only
 	int getAlleleIDAtLocus(short whichChromosome, int position) const;
 #endif
 
@@ -86,7 +86,7 @@ private:
 
 };
 
-#if RSDEBUG // for testing purposes only
+#ifndef NDEBUG // for testing purposes only
 map<int, vector<unsigned char>> createTestNeutralGenotype(
 	const int genomeSz, const bool isDiploid,
 	const unsigned char valAlleleA,

--- a/src/RScore/Parameters.h
+++ b/src/RScore/Parameters.h
@@ -415,7 +415,7 @@ private:
 	int outputGeneticInterval;
 };
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/RScore/Parameters.h
+++ b/src/RScore/Parameters.h
@@ -74,11 +74,7 @@ constexpr int gMaxNbSexes = 2;			// maximum number of sexes permitted
 #if RS_RCPP
 typedef intptr_t intptr;
 #else
-#if RSWIN64
 typedef unsigned long long intptr;
-#else
-typedef unsigned int intptr;
-#endif
 #endif // RS_RCPP
 
 #if RS_RCPP

--- a/src/RScore/Parameters.h
+++ b/src/RScore/Parameters.h
@@ -48,14 +48,9 @@
 #ifndef ParametersH
 #define ParametersH
 
- //#if LINUX_CLUSTER
- //#include <string.h>
- //#else
 #include <string>
-//#endif
 #include <fstream>
 #include <iostream>
-//#include <io.h>
 #include <iomanip>
 #include <stdlib.h>
 #include <vector>

--- a/src/RScore/Patch.cpp
+++ b/src/RScore/Patch.cpp
@@ -294,10 +294,6 @@ void Patch::resetPossSettlers(void) {
 
 // Record the presence of a potential settler within the Patch
 void Patch::incrPossSettler(Species* pSpecies, int sex) {
-#if RSDEBUG
-	//DEBUGLOG << "Patch::incrPossSettler(): 5555: patchNum = " << patchNum
-	//	<< " sex = " << sex << endl;
-#endif
 // NOTE: THE FOLLOWING OPERATION WILL NEED TO BE MADE SPECIES-SPECIFIC...
 	if (sex >= 0 && sex < gMaxNbSexes) {
 		nTemp[sex]++;
@@ -306,10 +302,6 @@ void Patch::incrPossSettler(Species* pSpecies, int sex) {
 
 // Get number of a potential settlers within the Patch
 int Patch::getPossSettlers(Species* pSpecies, int sex) {
-#if RSDEBUG
-	//DEBUGLOG << "Patch::getPossSettlers(): 5555: patchNum = " << patchNum
-	//	<< " sex = " << sex << endl;
-#endif
 // NOTE: THE FOLLOWING OPERATION WILL NEED TO BE MADE SPECIES-SPECIFIC...
 	if (sex >= 0 && sex < gMaxNbSexes) return nTemp[sex];
 	else return 0;

--- a/src/RScore/Patch.h
+++ b/src/RScore/Patch.h
@@ -166,7 +166,7 @@ private:
 extern paramStoch* paramsStoch;
 extern RSrandom* pRandom;
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/RScore/Population.cpp
+++ b/src/RScore/Population.cpp
@@ -671,7 +671,7 @@ void Population::reproduction(const float localK, const float envval, const int 
 					for (int j = 0; j < njuvs; j++) {
 
 						Individual* newJuv;
-#if RSDEBUG
+#ifndef NDEBUG
 						// NOTE: CURRENTLY SETTING ALL INDIVIDUALS TO RECORD NO. OF STEPS ...
 						newJuv = new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, true, trfr.moveType);
 #else
@@ -1519,11 +1519,11 @@ void Population::clean(void)
 		shuffle(inds.begin(), inds.end(), pRandom->getRNG());
 #else
 
-#if !RSDEBUG
-		// do not randomise individuals in RSDEBUG mode, as the function uses rand()
+#ifdef NDEBUG
+		// do not randomise individuals in DEBUG mode, as the function uses rand()
 		// and therefore the randomisation will differ between identical runs of RS
 		shuffle(inds.begin(), inds.end(), pRandom->getRNG());
-#endif // !RSDEBUG
+#endif // NDEBUG
 
 #endif // RS_RCPP
 	}
@@ -1699,7 +1699,7 @@ void Population::outIndsHeaders(int rep, int landNr, bool patchModel)
 		outInds << "\tS0\tAlphaS\tBetaS";
 	}
 	outInds << "\tDistMoved";
-#if RSDEBUG
+#ifndef NDEBUG
 	// ALWAYS WRITE NO. OF STEPS
 	outInds << "\tNsteps";
 #else
@@ -1814,7 +1814,7 @@ void Population::outIndividual(Landscape* pLandscape, int rep, int yr, int gen,
 					+ (natalloc.y - loc.y) * (natalloc.y - loc.y)));
 				outInds << "\t" << d;
 			}
-#if RSDEBUG
+#ifndef NDEBUG
 			// ALWAYS WRITE NO. OF STEPS
 			steps = inds[i]->getSteps();
 			outInds << "\t" << steps.year;

--- a/src/RScore/Population.cpp
+++ b/src/RScore/Population.cpp
@@ -675,7 +675,7 @@ void Population::reproduction(const float localK, const float envval, const int 
 						// NOTE: CURRENTLY SETTING ALL INDIVIDUALS TO RECORD NO. OF STEPS ...
 						newJuv = new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, true, trfr.moveType);
 #else
-						newJuv = new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, trfr.moveModel, trfr.moveType);
+						newJuv = new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, trfr.usesMovtProc, trfr.moveType);
 #endif
 
 						if (pSpecies->getNTraits() > 0) {
@@ -1703,7 +1703,7 @@ void Population::outIndsHeaders(int rep, int landNr, bool patchModel)
 	// ALWAYS WRITE NO. OF STEPS
 	outInds << "\tNsteps";
 #else
-	if (trfr.moveModel) outInds << "\tNsteps";
+	if (trfr.usesMovtProc) outInds << "\tNsteps";
 #endif
 	outInds << endl;
 }
@@ -1819,7 +1819,7 @@ void Population::outIndividual(Landscape* pLandscape, int rep, int yr, int gen,
 			steps = inds[i]->getSteps();
 			outInds << "\t" << steps.year;
 #else
-			if (trfr.moveModel) {
+			if (trfr.usesMovtProc) {
 				steps = inds[i]->getSteps();
 				outInds << "\t" << steps.year;
 			}

--- a/src/RScore/Population.h
+++ b/src/RScore/Population.h
@@ -229,10 +229,10 @@ public:
 	vector<int> countNbHeterozygotesEachLocus();
 	double computeHs();
 
-#if RSDEBUG
+#ifndef NDEBUG
 	// Testing only
 	void clearInds() { inds.clear(); } // empty inds vector to avoid deallocating individual is used separately in test
-#endif // RSDEBUG
+#endif // NDEBUG
 
 private:
 	short nStages;
@@ -258,7 +258,7 @@ extern paramInit* paramsInit;
 extern paramSim* paramsSim;
 extern RSrandom* pRandom;
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 

--- a/src/RScore/QuantitativeTrait.h
+++ b/src/RScore/QuantitativeTrait.h
@@ -26,7 +26,7 @@ public:
     virtual bool isHeterozygoteAtLocus(int loci) const = 0;
     virtual float express() = 0;
     virtual ~QuantitativeTrait() { }
-#if RSDEBUG // for testing only
+#ifndef NDEBUG // for testing only
 	virtual int getAlleleIDAtLocus(short whichChromosome, int position) const = 0;
 #endif
 };

--- a/src/RScore/RSrandom.cpp
+++ b/src/RScore/RSrandom.cpp
@@ -26,7 +26,7 @@
 
 #if !RS_RCPP
 
-#if RSDEBUG
+#ifndef NDEBUG
 #include "Parameters.h"
 extern paramSim* paramsSim;
 // ofstream RSRANDOMLOG;
@@ -36,8 +36,8 @@ int RS_random_seed = 0;
 
 // C'tor
 RSrandom::RSrandom() {
-#if RSDEBUG
-    // fixed seed
+#ifndef NDEBUG
+	// fixed seed
     RS_random_seed = 666;
 #else
     // random seed
@@ -48,11 +48,11 @@ RSrandom::RSrandom() {
 #else
     RS_random_seed = std::time(NULL);
 #endif
-#endif // RSDEBUG
+#endif // NDEBUG
 
-#if BATCH && RSDEBUG
+#ifndef NDEBUG
     DEBUGLOG << "RSrandom::RSrandom(): RS_random_seed=" << RS_random_seed << endl;
-#endif // RSDEBUG
+#endif
 
     // set up Mersenne Twister RNG
     gen = new mt19937(RS_random_seed);
@@ -143,7 +143,8 @@ void RSrandom::fixNewSeed(int seed) {
 
 //--------------- 3.) R package version of RSrandom.cpp
 
-#if RSDEBUG
+#ifndef NDEBUG
+
 #include "Parameters.h"
 extern paramSim* paramsSim;
 //ofstream RSRANDOMLOG;
@@ -167,14 +168,14 @@ RSrandom::RSrandom(std::int64_t seed)
 		std::random_device device;
 		random_seed[2] = device();
 #endif
-#if BATCH && RSDEBUG
+#ifndef NDEBUG
 		DEBUGLOG << "RSrandom::RSrandom(): Generated random seed = ";
 #endif
 	}
 	else {
 		// fixed seed
 		random_seed[2] = seed;
-#if BATCH && RSDEBUG
+#ifndef NDEBUG
 		DEBUGLOG << "RSrandom::RSrandom(): Use fixed seed = ";
 #endif
 	}
@@ -317,7 +318,8 @@ double RSrandom::Cauchy(double loc, double scale) {
 #endif // RS_RCPP
 
 
-#if RSDEBUG && !RS_RCPP
+#ifndef NDEBUG
+#if !RS_RCPP
 	void testRSrandom() {
 
 		{
@@ -339,5 +341,6 @@ double RSrandom::Cauchy(double loc, double scale) {
 			assert(bern_trial == 0 || bern_trial == 1);
 		}
 	}
-#endif // RSDEBUG
+#endif
+#endif // NDEBUG
 //---------------------------------------------------------------------------

--- a/src/RScore/RSrandom.cpp
+++ b/src/RScore/RSrandom.cpp
@@ -128,7 +128,7 @@ double RSrandom::Gamma(double shape, double scale) { //scale  = mean/shape, shap
 
 double RSrandom::NegExp(double mean) {
     double r1 = 0.0000001 + this->Random() * (1.0 - 0.0000001);
-    double x = (-1.0 * mean) * log(r1);  // for LINUX_CLUSTER
+    double x = (-1.0 * mean) * log(r1);
     return x;
 }
 
@@ -181,8 +181,10 @@ RSrandom::RSrandom(std::int64_t seed)
 	}
 
 	RS_random_seed = random_seed[2];
-#if BATCH && RSDEBUG
+#if BATCH 
+#ifndef	NDEBUG
 	DEBUGLOG << RS_random_seed << endl;
+#endif
 #endif
 
 	// set up Mersenne Twister random number generator with seed sequence
@@ -259,7 +261,7 @@ double RSrandom::Gamma(double shape, double scale) { //scale  = mean/shape, shap
 
 double RSrandom::NegExp(double mean) {
 	double r1 = 0.0000001 + this->Random() * (1.0 - 0.0000001);
-	double x = (-1.0 * mean) * log(r1);  // for LINUX_CLUSTER
+	double x = (-1.0 * mean) * log(r1);
 	return x;
 }
 

--- a/src/RScore/RSrandom.h
+++ b/src/RScore/RSrandom.h
@@ -43,7 +43,7 @@
 
 using namespace std;
 
-#if RSDEBUG
+#ifndef NDEBUG
 extern ofstream DEBUGLOG;
 #endif
 
@@ -133,9 +133,9 @@ private:
 
 #endif // !RS_RCPP
 
-#if RSDEBUG
+#ifndef NDEBUG
 	void testRSrandom();
-#endif // RSDEBUG
+#endif // NDEBUG
 
 //---------------------------------------------------------------------------
 

--- a/src/RScore/Species.cpp
+++ b/src/RScore/Species.cpp
@@ -791,7 +791,7 @@ void Species::setSamplePatchList(const set<int>& samplePatchList) {
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 
-#if RSDEBUG
+#ifndef NDEBUG
 // For testing purposes only
 
 demogrParams createDefaultHaploidDemogrParams() {
@@ -818,4 +818,4 @@ demogrParams createDefaultDiploidDemogrParams() {
 	return d;
 }
 
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/Species.h
+++ b/src/RScore/Species.h
@@ -577,7 +577,7 @@ private:
 // For testing purposes only
 demogrParams createDefaultHaploidDemogrParams();
 demogrParams createDefaultDiploidDemogrParams();
-#endif NDEBUG
+#endif // NDEBUG
 
 //---------------------------------------------------------------------------
 #endif

--- a/src/RScore/Species.h
+++ b/src/RScore/Species.h
@@ -573,11 +573,11 @@ private:
 
 //---------------------------------------------------------------------------
 
-#if RSDEBUG
+#ifndef NDEBUG
 // For testing purposes only
 demogrParams createDefaultHaploidDemogrParams();
 demogrParams createDefaultDiploidDemogrParams();
-#endif RSDEBUG
+#endif NDEBUG
 
 //---------------------------------------------------------------------------
 #endif

--- a/src/RScore/SpeciesTrait.cpp
+++ b/src/RScore/SpeciesTrait.cpp
@@ -185,8 +185,7 @@ bool SpeciesTrait::isValidTraitVal(const float& val) const {
 	}
 }
 
-#if RSDEBUG
-// Testing only
+#ifndef NDEBUG // Testing only
 
 // Create a default set of gene positions ranging from zero to genome size
 set<int> createTestGenePositions(const int genomeSz) {
@@ -271,4 +270,4 @@ SpeciesTrait* createTestNeutralSpTrait(const float& maxAlleleVal, const set<int>
 	return spTr;
 }
 
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/SpeciesTrait.h
+++ b/src/RScore/SpeciesTrait.h
@@ -85,13 +85,12 @@ private:
     map<GenParamType, float> mutationParameters;
 };
 
-#if RSDEBUG // Testing only
-
+#ifndef NDEBUG // Testing only
 // Create a default set of gene positions ranging from zero to genome size
 set<int> createTestGenePositions(const int genomeSz);
 SpeciesTrait* createTestEmigSpTrait(const set<int>& genePositions, const bool& isDiploid);
 SpeciesTrait* createTestGenLoadTrait(const set<int>& genePositions, const bool& isDiploid);
 SpeciesTrait* createTestNeutralSpTrait(const float& maxAlleleVal, const set<int>& genePositions, const bool& isDiploid);
-#endif // RSDEBUG
+#endif // NDEBUG
 
 #endif // SPECIESTRAITH

--- a/src/RScore/SubCommunity.cpp
+++ b/src/RScore/SubCommunity.cpp
@@ -434,10 +434,6 @@ void SubCommunity::ageIncrement(void) {
 
 // Find the population of a given species in a given patch
 Population* SubCommunity::findPop(Species* pSp, Patch* pPch) {
-#if RSDEBUG
-	DEBUGLOG << "SubCommunity::findPop(): this=" << this
-		<< endl;
-#endif
 
 	Population* pPop = 0;
 	popStats pop;

--- a/src/RScore/unit_tests/testIndividual.cpp
+++ b/src/RScore/unit_tests/testIndividual.cpp
@@ -1,4 +1,4 @@
-#if RSDEBUG
+#ifndef NDEBUG
 
 #include "../Individual.h"
 #include "../Population.h"
@@ -1338,4 +1338,4 @@ void testIndividual() {
 	
 }
 
-#endif //RSDEBUG
+#endif //NDEBUG

--- a/src/RScore/unit_tests/testNeutralStats.cpp
+++ b/src/RScore/unit_tests/testNeutralStats.cpp
@@ -1,4 +1,4 @@
-#if RSDEBUG
+#ifndef NDEBUG
 
 #include "../Community.h"
 
@@ -1059,4 +1059,4 @@ void testNeutralStats() {
 	}
 }
 
-#endif // RSDEBUG
+#endif // NDEBUG

--- a/src/RScore/unit_tests/testPopulation.cpp
+++ b/src/RScore/unit_tests/testPopulation.cpp
@@ -1,4 +1,4 @@
-#if RSDEBUG
+#ifndef NDEBUG
 
 #include "../Individual.h"
 #include "../Population.h"
@@ -279,4 +279,4 @@ void testPopulation()
 	}
 }
 
-#endif //RSDEBUG
+#endif // NDEBUG


### PR DESCRIPTION
- replace all RSDEBUG macros with (not) NDEBUG to make RangeShifter Debug mode match the compiler's Debug vs Release
- rm unnecessary RSWIN64 macro (32-bits build still passes)
- rm LINUX_CLUSTER macro where unnecessary